### PR TITLE
Add subroutine from bash

### DIFF
--- a/src/AbstractSubroutine.php
+++ b/src/AbstractSubroutine.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Enhavo\Component\Cli;
+
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+abstract class AbstractSubroutine
+{
+    /** @var InputInterface */
+    protected $input;
+
+    /** @var OutputInterface */
+    protected $output;
+
+    /** @var QuestionHelper */
+    protected $questionHelper;
+
+    /**
+     * Interactive constructor.
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @param QuestionHelper $questionHelper
+     */
+    public function __construct(InputInterface $input, OutputInterface $output, QuestionHelper $questionHelper)
+    {
+        $this->input = $input;
+        $this->output = $output;
+        $this->questionHelper = $questionHelper;
+    }
+}

--- a/src/Application.php
+++ b/src/Application.php
@@ -2,7 +2,14 @@
 
 namespace Enhavo\Component\Cli;
 
+use Enhavo\Component\Cli\Command\CreateUserCommand;
 use Enhavo\Component\Cli\Command\InitializeCommand;
+use Enhavo\Component\Cli\Command\InteractiveCommand;
+use Enhavo\Component\Cli\Command\MigrateCommand;
+use Enhavo\Component\Cli\Command\RecreateDatabaseCommand;
+use Enhavo\Component\Cli\Command\ResetProjectCommand;
+use Enhavo\Component\Cli\Command\SelfUpdateCommand;
+use Enhavo\Component\Cli\Command\UpdateCommand;
 use Symfony\Component\Console\Application as BaseApplication;
 use Symfony\Component\Console\Input\InputInterface;
 
@@ -17,7 +24,15 @@ class Application
 
     public function run(InputInterface $input): int
     {
-        $this->application->add(new InitializeCommand('init'));
+        $this->application->add(new CreateUserCommand('create-user'));
+        $this->application->add(new InitializeCommand('initialize'));
+        $this->application->add(new InteractiveCommand('interactive'));
+        $this->application->add(new MigrateCommand('migrate'));
+        $this->application->add(new RecreateDatabaseCommand('recreate-database'));
+        $this->application->add(new ResetProjectCommand('reset-project'));
+        $this->application->add(new UpdateCommand('update'));
+        $this->application->add(new SelfUpdateCommand('self-update'));
+        $this->application->setDefaultCommand('interactive');
         return $this->application->run($input);
     }
 }

--- a/src/Command/CreateUserCommand.php
+++ b/src/Command/CreateUserCommand.php
@@ -2,22 +2,22 @@
 
 namespace Enhavo\Component\Cli\Command;
 
-use Enhavo\Component\Cli\Subroutine\Initialize;
+use Enhavo\Component\Cli\Subroutine\CreateUser;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class InitializeCommand extends Command
+class CreateUserCommand extends Command
 {
     protected function configure()
     {
         $this
-            ->setDescription('Initialize freshly installed project')
+            ->setDescription('Create user for login')
         ;
     }
 
     public function execute(InputInterface $input, OutputInterface $output)
     {
-        return (new Initialize($input, $output, $this->getHelper('question')))();
+        return (new CreateUser($input, $output, $this->getHelper('question')))();
     }
 }

--- a/src/Command/InteractiveCommand.php
+++ b/src/Command/InteractiveCommand.php
@@ -2,22 +2,22 @@
 
 namespace Enhavo\Component\Cli\Command;
 
-use Enhavo\Component\Cli\Subroutine\Initialize;
+use Enhavo\Component\Cli\Subroutine\Interactive;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class InitializeCommand extends Command
+class InteractiveCommand extends Command
 {
     protected function configure()
     {
         $this
-            ->setDescription('Initialize freshly installed project')
+            ->setDescription('Interactive guide')
         ;
     }
 
     public function execute(InputInterface $input, OutputInterface $output)
     {
-        return (new Initialize($input, $output, $this->getHelper('question')))();
+        return (new Interactive($input, $output, $this->getHelper('question')))();
     }
 }

--- a/src/Command/MigrateCommand.php
+++ b/src/Command/MigrateCommand.php
@@ -2,22 +2,22 @@
 
 namespace Enhavo\Component\Cli\Command;
 
-use Enhavo\Component\Cli\Subroutine\Initialize;
+use Enhavo\Component\Cli\Subroutine\Migrate;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class InitializeCommand extends Command
+class MigrateCommand extends Command
 {
     protected function configure()
     {
         $this
-            ->setDescription('Initialize freshly installed project')
+            ->setDescription('Create/execute migrations')
         ;
     }
 
     public function execute(InputInterface $input, OutputInterface $output)
     {
-        return (new Initialize($input, $output, $this->getHelper('question')))();
+        return (new Migrate($input, $output, $this->getHelper('question')))();
     }
 }

--- a/src/Command/RecreateDatabaseCommand.php
+++ b/src/Command/RecreateDatabaseCommand.php
@@ -2,22 +2,22 @@
 
 namespace Enhavo\Component\Cli\Command;
 
-use Enhavo\Component\Cli\Subroutine\Initialize;
+use Enhavo\Component\Cli\Subroutine\RecreateDatabase;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class InitializeCommand extends Command
+class RecreateDatabaseCommand extends Command
 {
     protected function configure()
     {
         $this
-            ->setDescription('Initialize freshly installed project')
+            ->setDescription('Drop/create db')
         ;
     }
 
     public function execute(InputInterface $input, OutputInterface $output)
     {
-        return (new Initialize($input, $output, $this->getHelper('question')))();
+        return (new RecreateDatabase($input, $output, $this->getHelper('question')))();
     }
 }

--- a/src/Command/ResetProjectCommand.php
+++ b/src/Command/ResetProjectCommand.php
@@ -2,22 +2,22 @@
 
 namespace Enhavo\Component\Cli\Command;
 
-use Enhavo\Component\Cli\Subroutine\Initialize;
+use Enhavo\Component\Cli\Subroutine\ResetProject;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class InitializeCommand extends Command
+class ResetProjectCommand extends Command
 {
     protected function configure()
     {
         $this
-            ->setDescription('Initialize freshly installed project')
+            ->setDescription('Reset/fix non working project')
         ;
     }
 
     public function execute(InputInterface $input, OutputInterface $output)
     {
-        return (new Initialize($input, $output, $this->getHelper('question')))();
+        return (new ResetProject($input, $output, $this->getHelper('question')))();
     }
 }

--- a/src/Command/SelfUpdateCommand.php
+++ b/src/Command/SelfUpdateCommand.php
@@ -2,22 +2,22 @@
 
 namespace Enhavo\Component\Cli\Command;
 
-use Enhavo\Component\Cli\Subroutine\Initialize;
+use Enhavo\Component\Cli\Subroutine\SelfUpdate;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class InitializeCommand extends Command
+class SelfUpdateCommand extends Command
 {
     protected function configure()
     {
         $this
-            ->setDescription('Initialize freshly installed project')
+            ->setDescription('Update enhavo-cli')
         ;
     }
 
     public function execute(InputInterface $input, OutputInterface $output)
     {
-        return (new Initialize($input, $output, $this->getHelper('question')))();
+        return (new SelfUpdate($input, $output, $this->getHelper('question')))();
     }
 }

--- a/src/Command/UpdateCommand.php
+++ b/src/Command/UpdateCommand.php
@@ -2,22 +2,22 @@
 
 namespace Enhavo\Component\Cli\Command;
 
-use Enhavo\Component\Cli\Subroutine\Initialize;
+use Enhavo\Component\Cli\Subroutine\Update;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class InitializeCommand extends Command
+class UpdateCommand extends Command
 {
     protected function configure()
     {
         $this
-            ->setDescription('Initialize freshly installed project')
+            ->setDescription('Update project after git pull')
         ;
     }
 
     public function execute(InputInterface $input, OutputInterface $output)
     {
-        return (new Initialize($input, $output, $this->getHelper('question')))();
+        return (new Update($input, $output, $this->getHelper('question')))();
     }
 }

--- a/src/Subroutine/CreateUser.php
+++ b/src/Subroutine/CreateUser.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Enhavo\Component\Cli\Subroutine;
+
+use Enhavo\Component\Cli\AbstractSubroutine;
+use Enhavo\Component\Cli\SubroutineInterface;
+use Symfony\Component\Console\Command\Command;
+
+class CreateUser extends AbstractSubroutine implements SubroutineInterface
+{
+    public function __invoke(): int
+    {
+        return Command::SUCCESS;
+    }
+}

--- a/src/Subroutine/Initialize.php
+++ b/src/Subroutine/Initialize.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Enhavo\Component\Cli\Subroutine;
+
+use Enhavo\Component\Cli\AbstractSubroutine;
+use Enhavo\Component\Cli\SubroutineInterface;
+use Enhavo\Component\Cli\Task\ComposerInstall;
+use Symfony\Component\Console\Command\Command;
+
+class Initialize extends AbstractSubroutine implements SubroutineInterface
+{
+    public function __invoke(): int
+    {
+        (new ComposerInstall( $this->input, $this->output, $this->questionHelper))();
+        return Command::SUCCESS;
+    }
+}

--- a/src/Subroutine/Interactive.php
+++ b/src/Subroutine/Interactive.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Enhavo\Component\Cli\Subroutine;
+
+use Enhavo\Component\Cli\AbstractSubroutine;
+use Enhavo\Component\Cli\SubroutineInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Question\Question;
+
+class Interactive extends AbstractSubroutine implements SubroutineInterface
+{
+    public function __invoke(): int
+    {
+        $subroutine = null;
+        while($subroutine === null) {
+            $question = new Question('Choose a task:
+[i] initialize freshly installed project
+[u] update project after git pull
+[r] reset/fix non working project
+[d] drop/create db
+[m] create/execute migrations
+[l] create login
+[c] cancel
+type one of the options: ');
+            $option = $this->questionHelper->ask($this->input, $this->output, $question);
+
+            if ($option == 'i') {
+                $subroutine = new Initialize($this->input, $this->output, $this->questionHelper);
+            } elseif ($option == 'u') {
+                $subroutine = new Initialize($this->input, $this->output, $this->questionHelper);
+            } elseif ($option == 'r') {
+                $subroutine = new Initialize($this->input, $this->output, $this->questionHelper);
+            } elseif ($option == 'd') {
+                $subroutine = new Initialize($this->input, $this->output, $this->questionHelper);
+            } elseif ($option == 'm') {
+                $subroutine = new Initialize($this->input, $this->output, $this->questionHelper);
+            } elseif ($option == 'l') {
+                $subroutine = new Initialize($this->input, $this->output, $this->questionHelper);
+            } elseif ($option == 'c') {
+                $this->output->writeln('Abort');
+                return Command::SUCCESS;
+            } else {
+                $this->output->write('Please choose valid command');
+            }
+        }
+
+        if ($subroutine instanceof SubroutineInterface) {
+            return $subroutine();
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Subroutine/Migrate.php
+++ b/src/Subroutine/Migrate.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Enhavo\Component\Cli\Subroutine;
+
+use Enhavo\Component\Cli\AbstractSubroutine;
+use Enhavo\Component\Cli\SubroutineInterface;
+use Symfony\Component\Console\Command\Command;
+
+class Migrate extends AbstractSubroutine implements SubroutineInterface
+{
+    public function __invoke(): int
+    {
+        return Command::SUCCESS;
+    }
+}

--- a/src/Subroutine/RecreateDatabase.php
+++ b/src/Subroutine/RecreateDatabase.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Enhavo\Component\Cli\Subroutine;
+
+use Enhavo\Component\Cli\AbstractSubroutine;
+use Enhavo\Component\Cli\SubroutineInterface;
+use Symfony\Component\Console\Command\Command;
+
+class RecreateDatabase extends AbstractSubroutine implements SubroutineInterface
+{
+    public function __invoke(): int
+    {
+        return Command::SUCCESS;
+    }
+}

--- a/src/Subroutine/ResetProject.php
+++ b/src/Subroutine/ResetProject.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Enhavo\Component\Cli\Subroutine;
+
+use Enhavo\Component\Cli\AbstractSubroutine;
+use Enhavo\Component\Cli\SubroutineInterface;
+use Symfony\Component\Console\Command\Command;
+
+class ResetProject extends AbstractSubroutine implements SubroutineInterface
+{
+    public function __invoke(): int
+    {
+        return Command::SUCCESS;
+    }
+}

--- a/src/Subroutine/SelfUpdate.php
+++ b/src/Subroutine/SelfUpdate.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Enhavo\Component\Cli\Subroutine;
+
+use Enhavo\Component\Cli\AbstractSubroutine;
+use Enhavo\Component\Cli\SubroutineInterface;
+use Symfony\Component\Console\Command\Command;
+
+class SelfUpdate extends AbstractSubroutine implements SubroutineInterface
+{
+    public function __invoke(): int
+    {
+        return Command::SUCCESS;
+    }
+}

--- a/src/Subroutine/Update.php
+++ b/src/Subroutine/Update.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Enhavo\Component\Cli\Subroutine;
+
+use Enhavo\Component\Cli\AbstractSubroutine;
+use Enhavo\Component\Cli\SubroutineInterface;
+use Symfony\Component\Console\Command\Command;
+
+class Update extends AbstractSubroutine implements SubroutineInterface
+{
+    public function __invoke(): int
+    {
+        return Command::SUCCESS;
+    }
+}

--- a/src/SubroutineInterface.php
+++ b/src/SubroutineInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Enhavo\Component\Cli;
+
+interface SubroutineInterface
+{
+    public function __invoke(): int;
+}

--- a/src/Task/ComposerInstall.php
+++ b/src/Task/ComposerInstall.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Enhavo\Component\Cli\Task;
+
+use Enhavo\Component\Cli\AbstractSubroutine;
+use Symfony\Component\Console\Question\Question;
+use Symfony\Component\Process\Process;
+
+class ComposerInstall extends AbstractSubroutine
+{
+    public function __invoke()
+    {
+        while(true) {
+            $question = new Question('composer install? [y/n]', 'y');
+            $option = $this->questionHelper->ask($this->input, $this->output, $question);
+
+            if (strtolower($option) === 'n') {
+                return;
+            } elseif (strtolower($option) === 'y') {
+                $process = new Process(['composer', 'install']);
+                $process->start();
+                $iterator = $process->getIterator($process::ITER_SKIP_ERR | $process::ITER_KEEP_OUTPUT);
+                foreach ($iterator as $data) {
+                    $this->output->writeln($data);
+                }
+                return;
+            }
+        }
+    }
+}


### PR DESCRIPTION
The `bash` script contains subroutines. In order to migrate the `bash` script to `phar`, this PR add some skeleton classes for the subroutines