### PR TITLE
Add vendor symlink command

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -17,6 +17,7 @@ use Enhavo\Component\Cli\Command\RecreateDatabaseCommand;
 use Enhavo\Component\Cli\Command\ResetProjectCommand;
 use Enhavo\Component\Cli\Command\SelfUpdateCommand;
 use Enhavo\Component\Cli\Command\UpdateCommand;
+use Enhavo\Component\Cli\Command\VendorSymlinkCommand;
 use Symfony\Component\Console\Application as BaseApplication;
 use Symfony\Component\Console\Input\InputInterface;
 
@@ -46,6 +47,7 @@ class Application
         $this->application->add(new SelfUpdateCommand('self-update'));
         $this->application->add(new PushSubtreeCommand('push-subtree'));
         $this->application->add(new NpmReleaseCommand('npm-release'));
+        $this->application->add(new VendorSymlinkCommand('vendor-symlink'));
         $this->application->setDefaultCommand('interactive');
         return $this->application->run($input);
     }

--- a/src/Command/VendorSymlinkCommand.php
+++ b/src/Command/VendorSymlinkCommand.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Enhavo\Component\Cli\Command;
+
+use Enhavo\Component\Cli\Configuration\Factory;
+use Enhavo\Component\Cli\Subroutine\VendorSymlink;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class VendorSymlinkCommand extends Command
+{
+    protected function configure()
+    {
+        $this
+            ->setDescription('Create or delete a symlink to a main repository')
+            ->addArgument('package name', InputArgument::REQUIRED, 'package name e.g. enhavo/app-bundle')
+        ;
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        $packageName = $input->getArgument('package name');
+        return (new VendorSymlink($input, $output, $this->getHelper('question'), $packageName, (new Factory())->create(), new Factory()))();
+    }
+}

--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -34,6 +34,9 @@ class Configuration
     /** @var string|null */
     private $defaultUserPassword;
 
+    /** @var string[] */
+    private $mainRepositories = [];
+
     /**
      * @param Subtree $subtree
      */
@@ -192,5 +195,31 @@ class Configuration
     public function setDefaultUserPassword(?string $defaultUserPassword): void
     {
         $this->defaultUserPassword = $defaultUserPassword;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getMainRepositories(): array
+    {
+        return $this->mainRepositories;
+    }
+
+    /**
+     * @param string $mainRepository
+     */
+    public function addMainRepository(string $mainRepository)
+    {
+        $this->mainRepositories[] = $mainRepository;
+    }
+
+    /**
+     * @param string $mainRepository
+     */
+    public function removeMainRepository(string $mainRepository)
+    {
+        if (false !== $key = array_search($mainRepository, $this->mainRepositories, true)) {
+            array_splice($this->mainRepositories, $key, 1);
+        }
     }
 }

--- a/src/Configuration/Factory.php
+++ b/src/Configuration/Factory.php
@@ -47,14 +47,20 @@ class Factory
         return null;
     }
 
-    private function readFromFile(string $path, Configuration $configuration)
+    public function readFromFile(string $path, Configuration $configuration)
     {
         $content = file_get_contents($path);
         $config = Yaml::parse($content);
 
         if (isset($config['subtrees'])) {
             foreach($config['subtrees'] as $name => $subtree) {
-                $configuration->addSubtree(new Subtree($name, $subtree['url'], $subtree['prefix'], isset($subtree['push_tag']) ? $subtree['push_tag'] : true));
+                $configuration->addSubtree(new Subtree(
+                    $name,
+                    $subtree['url'],
+                    $subtree['prefix'],
+                    isset($subtree['package']) ? $subtree['package'] : null,
+                    isset($subtree['push_tag']) ? $subtree['push_tag'] : true
+                ));
             }
         }
 
@@ -94,6 +100,12 @@ class Factory
 
         if (isset($config['defaults']['database_port'])) {
             $configuration->setDefaultDatabasePort($config['defaults']['database_port']);
+        }
+
+        if (isset($config['mainRepositories'])) {
+            foreach ($config['mainRepositories'] as $repository) {
+                $configuration->addMainRepository($repository);
+            }
         }
     }
 

--- a/src/Configuration/Subtree.php
+++ b/src/Configuration/Subtree.php
@@ -16,6 +16,9 @@ class Subtree
     /** @var bool */
     private $pushTag;
 
+    /** @var string|null */
+    private $package;
+
     /**
      * Subtree constructor.
      * @param string $name
@@ -23,12 +26,13 @@ class Subtree
      * @param string $prefix
      * @param bool $pushTag
      */
-    public function __construct(string $name, string $url, string $prefix, bool $pushTag = true)
+    public function __construct(string $name, string $url, string $prefix, string $package = null, bool $pushTag = true)
     {
         $this->name = $name;
         $this->url = $url;
         $this->prefix = $prefix;
         $this->pushTag = $pushTag;
+        $this->package = $package;
     }
 
     /**
@@ -61,5 +65,13 @@ class Subtree
     public function isPushTag(): bool
     {
         return $this->pushTag;
+    }
+
+    /**
+     * @return ?string
+     */
+    public function getPackage(): ?string
+    {
+        return $this->package;
     }
 }

--- a/src/Git/Git.php
+++ b/src/Git/Git.php
@@ -267,6 +267,16 @@ class Git
         $this->execute(["git", "branch", "-D", $branchId]);
     }
 
+    public function deleteRemoteTag(string $remote, string $tag)
+    {
+        $this->execute(["git", "push", $remote, sprintf(':%s', $tag)]);
+    }
+
+    public function deleteTag(string $tag)
+    {
+        $this->execute(["git", "tag", '-d', $tag]);
+    }
+
     public function addSubtree(string $remote, string $prefix, string $remoteBranch = 'main')
     {
         $this->execute(["git", "subtree", "add", "--prefix", $prefix, "--squash", sprintf('%s/%s', $remote, $remoteBranch)]);

--- a/src/Subroutine/VendorSymlink.php
+++ b/src/Subroutine/VendorSymlink.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Enhavo\Component\Cli\Subroutine;
+
+use Enhavo\Component\Cli\AbstractSubroutine;
+use Enhavo\Component\Cli\Configuration\Configuration;
+use Enhavo\Component\Cli\Configuration\Factory;
+use Enhavo\Component\Cli\SubroutineInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Filesystem\Filesystem;
+
+class VendorSymlink extends AbstractSubroutine implements SubroutineInterface
+{
+    /** @var string */
+    private $packageName;
+
+    /** @var Filesystem */
+    private $fs;
+
+    /** @var Configuration */
+    private $configuration;
+
+    /** @var Factory */
+    private $factory;
+
+    /**
+     * NpmRelease constructor.
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @param QuestionHelper $questionHelper
+     * @param string $packageName
+     * @param Configuration $configuration
+     */
+    public function __construct(InputInterface $input, OutputInterface $output, QuestionHelper $questionHelper, $packageName, Configuration $configuration, Factory $factory)
+    {
+        parent::__construct($input, $output, $questionHelper);
+        $this->packageName = $packageName;
+        $this->fs = new Filesystem();
+        $this->configuration = $configuration;
+        $this->factory = $factory;
+    }
+
+    public function __invoke(): int
+    {
+        $path = $this->checkPackage();
+        if ($path === false) {
+            $this->output->writeln(sprintf('Package "%s" not found', $this->packageName));
+            return Command::FAILURE;
+        }
+
+        $this->output->writeln(sprintf('Package "%s" found', $this->packageName));
+
+        $mainRepositoryNames = $this->getMainRepositoryNames();
+        if (count($mainRepositoryNames) === 0) {
+            $this->output->writeln(sprintf('No main repository was defined in enhavo configuration'));
+            return Command::FAILURE;
+        }
+
+        $mainPackagePath = $this->findMainPackagePath();
+        if ($mainPackagePath === null) {
+            $this->output->writeln(sprintf('Package "%s" could not found in any main repositories: "%s"', $this->packageName, join(',', $mainRepositoryNames)));
+            return Command::FAILURE;
+        }
+
+        $this->fs->remove($path);
+        $this->fs->symlink($mainPackagePath, $path);
+
+        $this->output->writeln(sprintf('Package "%s" was symlinked to "%s"', $this->packageName, $mainPackagePath));
+
+        return Command::SUCCESS;
+    }
+
+    private function checkPackage()
+    {
+        $path = sprintf('%s/vendor/%s', getcwd(), $this->packageName);
+        if ($this->fs->exists($path)) {
+            return $path;
+        } else {
+            return false;
+        }
+    }
+
+    private function findMainPackagePath()
+    {
+        $mainRepositories = $this->configuration->getMainRepositories();
+
+        foreach ($mainRepositories as $mainRepository) {
+            $configPath = sprintf('%s/.enhavo.yml', $mainRepository);
+            if ($this->fs->exists($configPath)) {
+                $configuration = new Configuration();
+                $this->factory->readFromFile($configPath, $configuration);
+                foreach ($configuration->getSubtrees() as $subtree) {
+                    if ($subtree->getPackage() === $this->packageName) {
+                        return sprintf('%s/%s', $mainRepository, $subtree->getPrefix());
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private function getMainRepositoryNames(): array
+    {
+        $names = [];
+
+        $mainRepositories = $this->configuration->getMainRepositories();
+        foreach ($mainRepositories as $name => $mainRepository) {
+            $names[] = $name;
+        }
+
+        return $names;
+    }
+}


### PR DESCRIPTION
Add vendor symlink command to replace a vendor package with a symlink to its repository path. This is useful to simplify the workflow of editing vendor files. 