### PR TITLE
Migrate first before create migration

### DIFF
--- a/src/Subroutine/Migrate.php
+++ b/src/Subroutine/Migrate.php
@@ -27,6 +27,7 @@ class Migrate extends AbstractSubroutine implements SubroutineInterface
 
     public function __invoke(): int
     {
+        (new ExecuteMigrations($this->input, $this->output, $this->questionHelper))();
         (new CreateEnv($this->input, $this->output, $this->questionHelper, $this->configuration))();
         (new CreateMigrations($this->input, $this->output, $this->questionHelper))();
         $execute = (new ExecuteMigrations($this->input, $this->output, $this->questionHelper))();


### PR DESCRIPTION
Sometimes user forget to migrate first before creating a migration. With this PR, we will create a migration first